### PR TITLE
Use filepathx to support globstar recursive alias search

### DIFF
--- a/coderefs/alias.go
+++ b/coderefs/alias.go
@@ -16,6 +16,7 @@ import (
 	"github.com/launchdarkly/ld-find-code-refs/internal/helpers"
 	"github.com/launchdarkly/ld-find-code-refs/internal/validation"
 	"github.com/launchdarkly/ld-find-code-refs/options"
+	"github.com/yargevad/filepathx"
 )
 
 // GenerateAliases returns a map of flag keys to aliases based on config.
@@ -128,7 +129,7 @@ func processFileContent(aliases []options.Alias, dir string) (map[string][]byte,
 		paths := []string{}
 		for _, glob := range a.Paths {
 			absGlob := filepath.Join(dir, glob)
-			matches, err := filepath.Glob(absGlob)
+			matches, err := filepathx.Glob(absGlob)
 			if err != nil {
 				return nil, fmt.Errorf("filepattern '%s': could not process path glob '%s'", aliasId, absGlob)
 			}

--- a/coderefs/alias.go
+++ b/coderefs/alias.go
@@ -62,7 +62,7 @@ func generateAlias(a options.Alias, flag, dir string, allFileContents map[string
 		fileContents := []byte{}
 		for _, path := range a.Paths {
 			absGlob := filepath.Join(dir, path)
-			matches, err := filepath.Glob(absGlob)
+			matches, err := filepathx.Glob(absGlob)
 			if err != nil {
 				return nil, fmt.Errorf("could not process path glob '%s'", absGlob)
 			}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.3
 	github.com/stretchr/testify v1.4.0
+	github.com/yargevad/filepathx v1.0.0
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58 // indirect
 	golang.org/x/tools v0.0.0-20200825202427-b303f430e36d

--- a/go.sum
+++ b/go.sum
@@ -275,6 +275,8 @@ github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yargevad/filepathx v1.0.0 h1:SYcT+N3tYGi+NvazubCNlvgIPbzAk7i7y2dwg3I5FYc=
+github.com/yargevad/filepathx v1.0.0/go.mod h1:BprfX/gpYNJHJfc35GjRRpVcwWXS89gGulUIU5tK3tA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Switch from `filepath` to `filepathx` to enable things like the following config in `.launchdarkly/coderefs.yaml` that will allow searching for `var_name = 'FLAG_KEY'` anywhere in project
```
aliases:
  - type: filepattern
    paths:
      - '**/*.py'
    patterns:
      - '(\w+)\s*=\s*\"FLAG_KEY\"'
```